### PR TITLE
chore: Update worksheets to IDs

### DIFF
--- a/config/sources/cdc-tests.js
+++ b/config/sources/cdc-tests.js
@@ -6,7 +6,7 @@ module.exports = {
   tags: ['Internal Endpoints'],
   description: "Data on the CDC's public testing initiatives.",
   sheetId: '16gBHQ7dCJK1psqEMasmLKiFlzoNKcfNujVpmHLHldSY',
-  sheetIndex: 0,
+  worksheetId: 0,
   fieldDefinitions: [
     {
       source: 'dateCollected',

--- a/config/sources/press.js
+++ b/config/sources/press.js
@@ -7,7 +7,7 @@ module.exports = {
   description:
     'A list of news articles the COVID Tracking Project has appeared in.',
   sheetId: '17KJTUTRwh-2og9Kx0OIZ4Ix5dm_51TL330wwgYSfTBs',
-  sheetIndex: 1,
+  worksheetId: 0,
   fieldDefinitions: [
     {
       source: 'Title',

--- a/src/__mocks__/config.js
+++ b/src/__mocks__/config.js
@@ -2,8 +2,8 @@ const { DateTime } = require('luxon')
 const regularConfig = require('../../config')
 
 regularConfig.openApiPathPrefix = '/test-api/'
-regularConfig.sources.press.sheetIndex = 0
-regularConfig.sources.cdcTests.sheetIndex = 0
+regularConfig.sources.press.worksheetId = 0
+regularConfig.sources.cdcTests.worksheetId = 0
 regularConfig.sources.raceHomepage.worksheetId = 0
 regularConfig.sources.raceCombined.worksheetId = 0
 regularConfig.sources.raceSeparate.worksheetId = 0

--- a/src/__tests__/sources/cdc-tests.js
+++ b/src/__tests__/sources/cdc-tests.js
@@ -21,7 +21,7 @@ jest.mock('google-spreadsheet', () => ({
         resolve([])
       })
     },
-    sheetsByIndex: [
+    sheetsById: [
       {
         getRows: () => {
           return new Promise((resolve) => {

--- a/src/__tests__/sources/press.js
+++ b/src/__tests__/sources/press.js
@@ -22,7 +22,7 @@ jest.mock('google-spreadsheet', () => ({
         resolve([])
       })
     },
-    sheetsByIndex: [
+    sheetsById: [
       {
         getRows: () => {
           return new Promise((resolve) => {

--- a/src/sources/cdc-tests.js
+++ b/src/sources/cdc-tests.js
@@ -4,7 +4,7 @@ const mapFields = require('../utilities/map-fields')
 const { GoogleSpreadsheet } = require('google-spreadsheet')
 
 module.exports = (config) => {
-  const { sheetId, sheetIndex, fieldDefinitions } = config.sources.cdcTests
+  const { sheetId, worksheetId, fieldDefinitions } = config.sources.cdcTests
 
   const client = new GoogleSpreadsheet(sheetId)
 
@@ -12,7 +12,7 @@ module.exports = (config) => {
     return client
       .loadInfo()
       .then(() => {
-        const sheet = client.sheetsByIndex[sheetIndex]
+        const sheet = client.sheetsById[worksheetId]
         return sheet.getRows()
       })
       .then((rows) => rows)

--- a/src/sources/press.js
+++ b/src/sources/press.js
@@ -4,7 +4,7 @@ const mapFields = require('../utilities/map-fields')
 const { GoogleSpreadsheet } = require('google-spreadsheet')
 
 module.exports = (config) => {
-  const { sheetId, sheetIndex, fieldDefinitions } = config.sources.press
+  const { sheetId, worksheetId, fieldDefinitions } = config.sources.press
 
   const client = new GoogleSpreadsheet(sheetId)
 
@@ -12,7 +12,7 @@ module.exports = (config) => {
     return client
       .loadInfo()
       .then(() => {
-        const sheet = client.sheetsByIndex[sheetIndex]
+        const sheet = client.sheetsById[worksheetId]
         return sheet.getRows()
       })
       .then((rows) => rows)


### PR DESCRIPTION
Fixes #16 - uses absolute worksheet IDs rather than sheet indexes.