### PR TITLE
chore: Add summary and public source URLs

### DIFF
--- a/config/sources/states-info.js
+++ b/config/sources/states-info.js
@@ -4,7 +4,10 @@ module.exports = {
   schema: 'StatesInfo',
   path: 'states/info.{format}',
   tags: ['States Current and Historical Data'],
-  description: 'State metadata',
+  summary: 'State metadata',
+  description: `Basic information about states, including notes about our methodology and the websites we use to check for data.`,
+  xPublicSourceUrl:
+    'https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml#',
   sheetId: '18oVRrHj3c183mHmq3m89_163yuYltLNlOmPerQ18E8w',
   worksheetId: '1983833656',
   subDefinitions: [

--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -2,6 +2,9 @@ const { DateTime } = require('luxon')
 const objectHash = require('object-hash')
 const stateNames = require('../state-names')
 
+const xPublicSourceUrl =
+  'https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml#'
+
 const stateParameter = {
   name: 'state',
   in: 'path',
@@ -13,14 +16,17 @@ const stateParameter = {
     example: 'ca',
   },
   description:
-    'Use the two-letter state code to select the current value for a single state.',
+    'Use the lower-case two-letter state code to select the current value for a single state.',
 }
 
 module.exports = {
   schema: 'States',
   path: 'states/daily.{format}',
   tags: ['States Current and Historical Data'],
-  description: 'Historic values for all states',
+  summary: 'Historic values for all states',
+  description:
+    'Lists all COVID data available for every state since tracking started.',
+  xPublicSourceUrl,
   sheetId: '18oVRrHj3c183mHmq3m89_163yuYltLNlOmPerQ18E8w',
   worksheetId: '916628299',
   subDefinitions: [
@@ -29,14 +35,20 @@ module.exports = {
       schema: 'States',
       path: 'states/current.{format}',
       tags: ['States Current and Historical Data'],
-      description: 'Current values for all states',
+      summary: 'Current values for all states',
+      description:
+        'The most recent COVID data for every state. The current value may be different than today.',
+      xPublicSourceUrl,
     },
     {
       key: 'statesIndividualCurrent',
       schema: 'States',
       path: 'states/{state}/current.{format}',
       tags: ['States Current and Historical Data'],
-      description: 'Current values for a single state',
+      summary: 'Current values for a single state',
+      description:
+        'The most recent COVID data for a single state. The current value may be different than today. Use lower-case state codes in the URL.',
+      xPublicSourceUrl,
       parameters: [stateParameter],
     },
     {
@@ -44,7 +56,10 @@ module.exports = {
       schema: 'States',
       path: 'states/{state}/daily.{format}',
       tags: ['States Current and Historical Data'],
-      description: 'Historic values for a single state',
+      summary: 'Historic values for a single state',
+      description:
+        'All COVID data for a single state. Use lower-case state codes in the URL.',
+      xPublicSourceUrl,
       parameters: [stateParameter],
     },
     {
@@ -52,7 +67,10 @@ module.exports = {
       schema: 'States',
       path: 'states/{state}/{date}.{format}',
       tags: ['States Current and Historical Data'],
-      description: 'Values for a single state on a specific date',
+      summary: 'Values for a single state on a specific date',
+      description:
+        'All COVID values for a single state on a specific date. Use lower-case state codes in the URL.',
+      xPublicSourceUrl,
       parameters: [
         stateParameter,
         {

--- a/config/sources/status.js
+++ b/config/sources/status.js
@@ -2,7 +2,8 @@ module.exports = {
   schema: 'Status',
   path: 'status.{format}',
   tags: ['Status'],
-  description: 'API status',
+  summary: 'API status',
+  descriptoin: 'Information on the last time our API data was updated.',
   fieldDefinitions: [
     {
       source: 'buildTime',

--- a/config/sources/us.js
+++ b/config/sources/us.js
@@ -1,12 +1,17 @@
 const { DateTime } = require('luxon')
 const objectHash = require('object-hash')
 
+const xPublicSourceUrl =
+  'https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml#'
+
 module.exports = {
   schema: 'Us',
   formats: ['json', 'csv'],
   path: 'us/daily.{format}',
   tags: ['US Current and Historical Data'],
-  description: 'Historic US values',
+  summary: 'Historic US values',
+  description: 'All COVID data for the US.',
+  xPublicSourceUrl,
   sheetId: '18oVRrHj3c183mHmq3m89_163yuYltLNlOmPerQ18E8w',
   worksheetId: '964640830',
   subDefinitions: [
@@ -15,14 +20,19 @@ module.exports = {
       schema: 'Us',
       path: 'us/current.{format}',
       tags: ['US Current and Historical Data'],
-      description: 'Current US values',
+      summary: 'Current US values',
+      description:
+        'The most recent COVID data for the US. The most recent data may not be from today.',
+      xPublicSourceUrl,
     },
     {
       key: 'usDates',
       schema: 'Us',
       path: 'us/{date}.{format}',
       tags: ['US Current and Historical Data'],
-      description: 'US historic values for a date',
+      summary: 'US historic values for a date',
+      description: 'All COVID data for the US on a specific date.',
+      xPublicSourceUrl,
       parameters: [
         {
           name: 'date',

--- a/src/output/openapi.js
+++ b/src/output/openapi.js
@@ -23,7 +23,9 @@ module.exports = (config) => {
     return {
       get: {
         tags: source.tags,
+        summary: source.summary || source.description,
         description: source.description,
+        'x-public-source-url': source.xPublicSourceUrl || false,
         responses: {
           '200': {
             description: 'OK',


### PR DESCRIPTION
- Changed `description` fields to `summary` and added more descriptions to our public endpoints.
- Added new `x-public-source-url` field to paths, so we can link to sheets.