### PR TITLE
docs: mark totalTestResults field as *not* deprecated

### DIFF
--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -188,7 +188,7 @@ module.exports = {
       target: 'totalTestResults',
       type: 'integer',
       graphQlType: 'Int',
-      description: 'Deprecated',
+      description: 'Total Test Results Provided by the State',
       nullable: true,
       example: '',
       sourceFunction: (item) => item.positive + item.negative,


### PR DESCRIPTION
Closes https://github.com/COVID19Tracking/covid-public-api-build/issues/56