### PR TITLE
chore: Update ND, MA codes for total test results

### DIFF
--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -232,8 +232,11 @@ module.exports = {
       nullable: true,
       example: 'posNeg',
       sourceFunction: (item) => {
-        if (['RI', 'CO'].indexOf(item.state) > -1) {
+        if (['RI', 'CO', 'ND'].indexOf(item.state) > -1) {
           return 'totalTestEncountersViral'
+        }
+        if (['MA'].indexOf(item.state) > -1) {
+          return 'totalTestsViral'
         }
         return 'posNeg'
       },
@@ -248,8 +251,11 @@ module.exports = {
       nullable: true,
       example: '',
       sourceFunction: (item) => {
-        if (['RI', 'CO'].indexOf(item.state) > -1) {
+        if (['RI', 'CO', 'ND'].indexOf(item.state) > -1) {
           return item.totalTestEncountersViral
+        }
+        if (['MA'].indexOf(item.state) > -1) {
+          return item.totalTestsViral
         }
         return item.positive + item.negative
       },


### PR DESCRIPTION
Adds ND to the list of states that use `totalTestEncountersViral`
Makes MA use `totalTestsViral`