### PR TITLE
Update totalTestResults on internal-endpoints branch

### DIFF
--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -233,8 +233,11 @@ module.exports = {
       nullable: true,
       example: 'posNeg',
       sourceFunction: (item) => {
-        if (['RI', 'CO'].indexOf(item.state) > -1) {
+        if (['RI', 'CO', 'ND'].indexOf(item.state) > -1) {
           return 'totalTestEncountersViral'
+        }
+        if (['MA'].indexOf(item.state) > -1) {
+          return 'totalTestsViral'
         }
         return 'posNeg'
       },
@@ -249,8 +252,11 @@ module.exports = {
       nullable: true,
       example: '',
       sourceFunction: (item) => {
-        if (['RI', 'CO'].indexOf(item.state) > -1) {
+        if (['RI', 'CO', 'ND'].indexOf(item.state) > -1) {
           return item.totalTestEncountersViral
+        }
+        if (['MA'].indexOf(item.state) > -1) {
+          return item.totalTestsViral
         }
         return item.positive + item.negative
       },


### PR DESCRIPTION
All this annoying PR does is cherry-pick the commit `chore: Update ND, MA codes` into the `internal-endpoints` branch. 

This should silence the comparison at https://internal.covidtracking.com/compare. 