### PR TITLE
fix: use correct internal sources for new site fields

### DIFF
--- a/config/sources/states-info.js
+++ b/config/sources/states-info.js
@@ -106,7 +106,7 @@ module.exports = {
       example: 'http://dhss.alaska.gov/dph/Epi/id/Pages/COVID-19/default.asp',
     },
     {
-      source: 'COVID-19 site (quaternary)',
+      source: 'covid19SiteQuaternary',
       target: 'covid19SiteQuaternary',
       type: 'string',
       graphQlType: 'String',
@@ -115,7 +115,7 @@ module.exports = {
       example: 'http://dhss.alaska.gov/dph/Epi/id/Pages/COVID-19/default.asp',
     },
     {
-      source: 'COVID-19 site (quinary)',
+      source: 'covid19SiteQuinary',
       target: 'covid19SiteQuinary',
       type: 'string',
       graphQlType: 'String',


### PR DESCRIPTION
I flubbed this up the first time. Just cherry-picking your commit wasn't enough since the internal fields have different names. Sorry for the extra work.

I think this should work, but at some point I should find out how to test these things locally to streamline this process.