### PR TITLE
fix: default totalTestResultsIncrease to 0 instead of null

### DIFF
--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -255,7 +255,7 @@ module.exports = {
       description: 'Daily Difference in totalTestResults',
       nullable: true,
       example: '',
-      sourceFunction: (item) => 0,
+      sourceFunction: (item) => item.totalTestResultsIncrease ? item.totalTestResultsIncrease : 0,
       metadata: {
         sheetColumn: '"Positive" & "Negative"',
         internalNote:

--- a/config/sources/states.js
+++ b/config/sources/states.js
@@ -255,6 +255,7 @@ module.exports = {
       description: 'Daily Difference in totalTestResults',
       nullable: true,
       example: '',
+      sourceFunction: (item) => 0,
       metadata: {
         sheetColumn: '"Positive" & "Negative"',
         internalNote:


### PR DESCRIPTION
This turns the default`totalTestResultsIncrease":null` into `totalTestResultsIncrease":0` to match the current behavior on the master branch when outputting the first earliest row of a state.