### PR TITLE
chore: Reset refs for staging build

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,6 @@ jobs:
       - name: Checkout build repo
         uses: actions/checkout@v2
         with:
-          ref: feature/internal-endpoints
           path: ./
 
       - name: Checkout data repo


### PR DESCRIPTION
Uses `master` ref for staging build